### PR TITLE
chore: update golangci-lint configs & workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go-version: [~1.12, ^1]
+        go-version: [~1.18, ^1]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/lint-soft.yml
+++ b/.github/workflows/lint-soft.yml
@@ -1,6 +1,8 @@
 name: lint-soft
 on:
   push:
+    branches:
+      - main
   pull_request:
 
 permissions:
@@ -13,9 +15,12 @@ jobs:
     name: lint-soft
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6.0.0
+        with:
+          go-version: stable
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v8
         with:
           # Optional: golangci-lint command line arguments.
           args: --config .golangci-soft.yml --issues-exit-code=0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,8 @@
 name: lint
 on:
   push:
+    branches:
+      - main
   pull_request:
 
 permissions:
@@ -13,9 +15,12 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6.0.0
+        with:
+          go-version: stable
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v8
         with:
           # Optional: golangci-lint command line arguments.
           #args:

--- a/.golangci-soft.yml
+++ b/.golangci-soft.yml
@@ -1,47 +1,35 @@
+version: "2"
 run:
   tests: false
-
-issues:
-  include:
-    - EXC0001
-    - EXC0005
-    - EXC0011
-    - EXC0012
-    - EXC0013
-
-  max-issues-per-linter: 0
-  max-same-issues: 0
-
 linters:
   enable:
-    # - dupl
     - exhaustive
-    # - exhaustivestruct
     - goconst
     - godot
     - godox
-    - gomnd
     - gomoddirectives
     - goprintffuncname
-    - ifshort
-    # - lll
     - misspell
+    - mnd
     - nakedret
     - nestif
     - noctx
     - nolintlint
     - prealloc
     - wrapcheck
-
-  # disable default linters, they are already enabled in .golangci.yml
   disable:
-    - deadcode
     - errcheck
-    - gosimple
     - govet
     - ineffassign
     - staticcheck
-    - structcheck
-    - typecheck
     - unused
-    - varcheck
+  exclusions:
+    generated: lax
+    presets:
+      - common-false-positives
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+formatters:
+  exclusions:
+    generated: lax

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,22 +1,9 @@
+version: "2"
 run:
   tests: false
-
-issues:
-  include:
-    - EXC0001
-    - EXC0005
-    - EXC0011
-    - EXC0012
-    - EXC0013
-
-  max-issues-per-linter: 0
-  max-same-issues: 0
-
 linters:
   enable:
     - bodyclose
-    - exportloopref
-    - goimports
     - gosec
     - nilerr
     - predeclared
@@ -27,3 +14,15 @@ linters:
     - unconvert
     - unparam
     - whitespace
+  exclusions:
+    generated: lax
+    presets:
+      - common-false-positives
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+formatters:
+  enable:
+    - goimports
+  exclusions:
+    generated: lax

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/muesli/mango-pflag
 
-go 1.17
+go 1.18
 
 require (
 	github.com/muesli/mango v0.2.0


### PR DESCRIPTION
Bump to v2 and Go 1.18+.